### PR TITLE
Update python_version for 3.13

### DIFF
--- a/mobileiron.json
+++ b/mobileiron.json
@@ -6,7 +6,7 @@
     "type": "endpoint",
     "main_module": "mobileiron_connector.py",
     "app_version": "2.0.1",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "utctime_updated": "2025-04-29T22:39:20.435621Z",
     "package_name": "phantom_mobileiron",
     "product_vendor": "MobileIron",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)